### PR TITLE
Allow editing user scores like tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -737,14 +737,24 @@ body#login-body {
     margin: 0 4px;
     display: none;
 }
+.hnes-scoreForm {
+    display: none;
+}
+.hnes-scoreEdit {
+    padding-left: 2px;
+    width: 54px;
+    margin: 0 4px 0 0;
+}
 .hnes-tagImage {
   margin-right: 3px;
   margin-bottom: 3px;
 }
-.hnes-tag-cont.edit .hnes-tagText {
+.hnes-tag-cont.edit .hnes-tagText,
+.hnes-tag-cont.edit .hnes-scoreForm {
     display: none;
 }
-.hnes-tag-cont.edit .hnes-tagEdit {
+.hnes-tag-cont.edit .hnes-tagEdit:not(.hidden),
+.hnes-tag-cont.edit .hnes-scoreForm:not(.hidden) {
     display: initial;
 }
 

--- a/style.css
+++ b/style.css
@@ -744,6 +744,7 @@ body#login-body {
     padding-left: 2px;
     width: 54px;
     margin: 0 4px 0 0;
+    font-size: 12px !important;
 }
 .hnes-tagImage {
   margin-right: 3px;


### PR DESCRIPTION
This pull request adds an edit box which lets you edit that specific user's score.  
Accessed using the "Tag user" button.

---

Hello, I am a user [your updated fork of HNES for Firefox](https://addons.mozilla.org/en-US/firefox/addon/miglior-for-hacker-news/).  
I keep accidently clicking upvote instead of the collapse [-] button which resulted in me writing this editable scores functionality.

The main repo etcet/HNES seems to be unmaintained. Could you merge this feature and push an update to the amo?